### PR TITLE
Add private pastie

### DIFF
--- a/doc/pastie.txt
+++ b/doc/pastie.txt
@@ -61,4 +61,7 @@ and in previous versions, :match (use ":match none" to disable).
 The URL sometimes disappears with the bang (:Pastie!) variant.  You can still
 retrieve it from the clipboard.
 
+If you want to create a private pastie you'll need to update `pastie_private`
+        $ let pastie_private = 1
+
  vim:tw=78:et:ft=help:norl:


### PR DESCRIPTION
Here is a quick fix to allow users to add private pasties. Simply set `pastie_private` to 1 in your vim config or on the fly `:let pastie_private=1`.